### PR TITLE
Update confusing __repr__ on SearchQuery

### DIFF
--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -399,7 +399,7 @@ class SearchQuery(models.Model):
 
     def __repr__(self):
         return (
-            u"<QueryLog id=%s user=%s index='%s' total_hits=%i >" % (
+            u"<SearchQuery id=%s user=%s index='%s' total_hits=%i >" % (
                 self.id, self.user, self.index, self.total_hits
             )
         )


### PR DESCRIPTION
I assume QueryLog was an old name but it led me to look for that class for a little bit before realising what the object really was.