### PR TITLE
Support swappable user model.

### DIFF
--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import logging
 import time
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.core.serializers.json import DjangoJSONEncoder
@@ -357,7 +358,7 @@ class SearchQuery(models.Model):
     """
 
     user = models.ForeignKey(
-        User,
+        settings.AUTH_USER_MODEL,
         related_name='search_queries',
         blank=True, null=True,
         help_text="The user who made the search query (nullable)."

--- a/elasticsearch_django/tests/test_models.py
+++ b/elasticsearch_django/tests/test_models.py
@@ -207,7 +207,7 @@ class SearchDocumentManagerMixinTests(TestCase):
         """Test the _raw_sql method."""
         self.assertEqual(
             TestModel.objects._raw_sql(((1, 2), (3, 4))),
-            "SELECT CASE elasticsearch_django_testmodel.id WHEN 1 THEN 2 WHEN 3 THEN 4 ELSE 0 END"
+            'SELECT CASE elasticsearch_django_testmodel."id" WHEN 1 THEN 2 WHEN 3 THEN 4 ELSE 0 END'
         )
 
     @mock.patch('django.db.models.query.QuerySet')
@@ -218,8 +218,8 @@ class SearchDocumentManagerMixinTests(TestCase):
         self.assertEqual(
             str(qs.query),
             'SELECT "elasticsearch_django_testmodel"."id", '
-            '(SELECT CASE elasticsearch_django_testmodel.id WHEN 1 THEN 1 WHEN 2 THEN 2 ELSE 0 END) '  # noqa
-            'AS "search_score", (SELECT CASE elasticsearch_django_testmodel.id WHEN 1 THEN 0 WHEN 2 '  # noqa
+            '(SELECT CASE elasticsearch_django_testmodel."id" WHEN 1 THEN 1 WHEN 2 THEN 2 ELSE 0 END) '  # noqa
+            'AS "search_score", (SELECT CASE elasticsearch_django_testmodel."id" WHEN 1 THEN 0 WHEN 2 '  # noqa
             'THEN 1 ELSE 0 END) AS "search_rank" FROM "elasticsearch_django_testmodel" WHERE '
             '"elasticsearch_django_testmodel"."id" IN (1, 2) ORDER BY "search_rank" ASC'
         )


### PR DESCRIPTION
elasticsearch_django doesn't support swappable user models.
When non-default user model is used I get the following exception:
```
Performing system checks...
ERRORS:
elasticsearch_django.SearchQuery.user: (fields.E301) Field defines a relation with the model 'auth.User', which has been swapped out.
	HINT: Update the relation to point at 'settings.AUTH_USER_MODEL'.
```

Also, elasticsearch assumes that model primary key is always named `id` and is an `IntegerField` which is a really strange assumption as almost every project I've worked with has different names for primary keys and sometimes they have different type (for example, UUID primary keys).

This pull request fixes the problem.