### PR TITLE
Update to support Elasticsearch 5.x

### DIFF
--- a/elasticsearch_django/management/commands/__init__.py
+++ b/elasticsearch_django/management/commands/__init__.py
@@ -18,7 +18,7 @@ class BaseSearchCommand(BaseCommand):
     def _confirm_action(self):
         """Return True if the user confirms the action."""
         msg = "Are you sure you wish to continue? [y/N] "
-        return input(msg).lower().startswith('y')
+        return raw_input(msg).lower().startswith('y')
 
     def add_arguments(self, parser):
         """Add default base options of --noinput and indexes."""
@@ -50,7 +50,7 @@ class BaseSearchCommand(BaseCommand):
                 data = {
                     "index": index,
                     "status": ex.status_code,
-                    "reason": ex.info['error']['reason']
+                    "reason": ex.error,
                 }
             finally:
                 logger.info(data)

--- a/elasticsearch_django/management/commands/create_search_index.py
+++ b/elasticsearch_django/management/commands/create_search_index.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Create a search index."""
-from elasticsearch_django.management.commands import BaseSearchCommand
-from elasticsearch_django.index import create_index
+from . import BaseSearchCommand
+from ...index import create_index
 
 
 class Command(BaseSearchCommand):

--- a/elasticsearch_django/management/commands/delete_search_index.py
+++ b/elasticsearch_django/management/commands/delete_search_index.py
@@ -2,8 +2,8 @@
 """Delete a search index (and all documents therein)."""
 import logging
 
-from elasticsearch_django.management.commands import BaseSearchCommand
-from elasticsearch_django.index import delete_index
+from . import BaseSearchCommand
+from ...index import delete_index
 
 logger = logging.getLogger(__name__)
 

--- a/elasticsearch_django/management/commands/prune_search_index.py
+++ b/elasticsearch_django/management/commands/prune_search_index.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Remove all documents in a search index that no longer exist in source queryset."""
-from elasticsearch_django.management.commands import BaseSearchCommand
-from elasticsearch_django.index import prune_index
+from . import BaseSearchCommand
+from ...index import prune_index
 
 
 class Command(BaseSearchCommand):

--- a/elasticsearch_django/management/commands/rebuild_search_index.py
+++ b/elasticsearch_django/management/commands/rebuild_search_index.py
@@ -2,8 +2,10 @@
 """Create a search index."""
 import logging
 
-from elasticsearch_django.management.commands import BaseSearchCommand
-from elasticsearch_django.index import (
+from elasticsearch.exceptions import TransportError
+
+from . import BaseSearchCommand
+from ...index import (
     delete_index,
     create_index,
     update_index
@@ -27,7 +29,10 @@ class Command(BaseSearchCommand):
                 logger.warn("Aborting rebuild of index '%s' at user's request.", index)
                 return
 
-        delete = delete_index(index)
+        try:
+            delete = delete_index(index)
+        except TransportError:
+            logger.info("Index %s does not exist, cannot be deleted.", index)
         create = create_index(index)
         update = update_index(index)
 

--- a/elasticsearch_django/management/commands/update_search_index.py
+++ b/elasticsearch_django/management/commands/update_search_index.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Update all documents in a search index."""
-from elasticsearch_django.management.commands import BaseSearchCommand
-from elasticsearch_django.index import update_index
+from . import BaseSearchCommand
+from ...index import update_index
 
 
 class Command(BaseSearchCommand):

--- a/elasticsearch_django/tests/test_settings.py
+++ b/elasticsearch_django/tests/test_settings.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -42,11 +44,9 @@ class SettingsFunctionTests(TestCase):
     def test_get_client(self, mock_conn):
         """Test the get_client function."""
         mock_conn.return_value = "http://foo"
-        client = get_client('foo')
-        self.assertEqual(
-            client.transport.hosts,
-            [{'host': 'foo', 'scheme': 'http'}]
-        )
+        client = get_client()
+        self.assertEqual(len(client.transport.hosts), 1)
+        self.assertEqual(client.transport.hosts[0]['host'], 'foo')
 
     @override_settings(SEARCH_SETTINGS=TEST_SETTINGS)
     def test_get_settings(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-Django>=1.11
-elasticsearch>=2.4
-elasticsearch-dsl>=2.1
-psycopg2>=2.6
-simplejson>=3.8

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ chdir(path.normpath(path.join(path.abspath(__file__), pardir)))
 
 setup(
     name="elasticsearch-django",
-    version="0.7",
+    version="5.0",
     packages=find_packages(),
     install_requires=[
         'Django>=1.9',
-        'elasticsearch>=2.4,<3',
-        'elasticsearch-dsl>=2.1,<3',
+        'elasticsearch>=5',
+        'elasticsearch-dsl>=5',
         'psycopg2>=2.6',
         'simplejson>=3.8',
     ],


### PR DESCRIPTION
Update the client packages (elasticsearch and elasticsearch_dsl) to their 5.x
compatible versions. Also fixes a couple of bugs.

Once this branch is merged, the master version will no longer (officially) support ES 2.x. I will
release another version of the master as 2.0, which will be the final 2.x supporting version, and
then release this as 5.0.
