### PR TITLE
Fix bug in rebuild_search_index

### DIFF
--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -44,7 +44,7 @@ def _validate_mapping(index, strict=False):
         if strict:
             raise ImproperlyConfigured("Index '%s' has no mapping file." % index)
         else:
-            logger.warn("Index '%s' has no mapping, relying on ES instead.", index)
+            logger.warning("Index '%s' has no mapping, relying on ES instead.", index)
 
 
 def _validate_model(model):

--- a/elasticsearch_django/management/commands/__init__.py
+++ b/elasticsearch_django/management/commands/__init__.py
@@ -48,7 +48,7 @@ class BaseSearchCommand(BaseCommand):
             try:
                 data = self.do_index_command(index, **options)
             except TransportError as ex:
-                logger.warn("ElasticSearch threw an error: %s", ex)
+                logger.warning("ElasticSearch threw an error: %s", ex)
                 data = {
                     "index": index,
                     "status": ex.status_code,

--- a/elasticsearch_django/management/commands/delete_search_index.py
+++ b/elasticsearch_django/management/commands/delete_search_index.py
@@ -18,8 +18,8 @@ class Command(BaseSearchCommand):
     def do_index_command(self, index, **options):
         """Delete search index."""
         if options['interactive']:
-            logger.warn("This will permanently delete the index '%s'.", index)
+            logger.warning("This will permanently delete the index '%s'.", index)
             if not self._confirm_action():
-                logger.warn("Aborting deletion of index '%s' at user's request.", index)
+                logger.warning("Aborting deletion of index '%s' at user's request.", index)
                 return
         return delete_index(index)

--- a/elasticsearch_django/management/commands/rebuild_search_index.py
+++ b/elasticsearch_django/management/commands/rebuild_search_index.py
@@ -32,6 +32,7 @@ class Command(BaseSearchCommand):
         try:
             delete = delete_index(index)
         except TransportError:
+            delete = {}
             logger.info("Index %s does not exist, cannot be deleted.", index)
         create = create_index(index)
         update = update_index(index)

--- a/elasticsearch_django/management/commands/rebuild_search_index.py
+++ b/elasticsearch_django/management/commands/rebuild_search_index.py
@@ -24,9 +24,9 @@ class Command(BaseSearchCommand):
     def do_index_command(self, index, **options):
         """Rebuild search index."""
         if options['interactive']:
-            logger.warn("This will permanently delete the index '%s'.", index)
+            logger.warning("This will permanently delete the index '%s'.", index)
             if not self._confirm_action():
-                logger.warn("Aborting rebuild of index '%s' at user's request.", index)
+                logger.warning("Aborting rebuild of index '%s' at user's request.", index)
                 return
 
         try:

--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -283,7 +283,7 @@ class SearchDocumentMixin(object):
             return None
 
         if action == 'update':
-            logger.warn(
+            logger.warning(
                 "'update' action is unsupported - switching to 'index' instead."
             )
             action = 'index'

--- a/elasticsearch_django/tests/test_commands.py
+++ b/elasticsearch_django/tests/test_commands.py
@@ -30,7 +30,7 @@ class BaseSearchCommandTests(TestCase):
         mock_do.side_effect = TransportError(123, "oops", {'error': {'reason': 'no idea'}})
         obj.handle(indexes=['baz'])
         mock_do.assert_called_once_with('baz')
-        mock_log.warn.assert_called_once()
+        mock_log.warning.assert_called_once()
 
 
 class NamedCommandTests(TestCase):

--- a/elasticsearch_django/tests/test_commands.py
+++ b/elasticsearch_django/tests/test_commands.py
@@ -77,10 +77,17 @@ class NamedCommandTests(TestCase):
     @mock.patch('elasticsearch_django.management.commands.rebuild_search_index.delete_index')
     @mock.patch('elasticsearch_django.management.commands.rebuild_search_index.create_index')
     @mock.patch('elasticsearch_django.management.commands.rebuild_search_index.update_index')
-    def test_update_search_index(self, mock_update, mock_create, mock_delete):
+    def test_rebuild_search_index(self, mock_update, mock_create, mock_delete):
         """Test the rebuild_search_index command."""
         cmd = rebuild_search_index.Command()
-        cmd.do_index_command('foo', interactive=False)  # True would hang the tests
+        result = cmd.do_index_command('foo', interactive=False)  # True would hang the tests
         mock_delete.assert_called_once_with('foo')
         mock_create.assert_called_once_with('foo')
         mock_update.assert_called_once_with('foo')
+        self.assertEqual(result['delete'], mock_delete.return_value)
+        self.assertEqual(result['create'], mock_create.return_value)
+        self.assertEqual(result['update'], mock_update.return_value)
+        # check that the delete is handled if the index does not exist
+        mock_delete.side_effect = TransportError("Index not found")
+        result = cmd.do_index_command('foo', interactive=False)  # True would hang the tests
+        self.assertEqual(result['delete'], {})


### PR DESCRIPTION
Fixes issue #12 - if the index does not exist, the delete command fails,
and although this was handled, the delete return value was not initialiased
so the return value from the command itself failed. Now returns an empty
dict if the delete fails.