### PR TITLE
Update index delete actions to ignore search queryset

### DIFF
--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -263,8 +263,8 @@ class SearchDocumentMixin(object):
             index: string, the name of the index to update. Defaults to '_all',
                 which is a reserved ES term meaning all indexes. In this case we
                 use the config to look up all configured indexes for the model.
-            force: bool, if True then ignore caching and force the update. Defaults
-                to False.
+            force: bool, if True then ignore the in_search_queryset check and run
+                the update regardless.
 
         NB In reality we only support 'index' and 'delete' - 'update' is really
         a PATCH operation, updating partial documents in the search index - and
@@ -276,7 +276,9 @@ class SearchDocumentMixin(object):
         assert action in ('index', 'update', 'delete'), ("Action must be 'index', 'update' or 'delete'.")  # noqa
         assert self.id, ("Object must have a primary key before being indexed.")
 
-        if not self.__class__.objects.in_search_queryset(self.id, index=index):
+        if force is True:
+            logger.debug("Forcing search index update: {} {}".format(action, self))
+        elif not self.__class__.objects.in_search_queryset(self.id, index=index):
             logger.debug(
                 "{} is not in the source queryset for '{}', aborting update.".format(self, index)
             )

--- a/elasticsearch_django/tests/test_models.py
+++ b/elasticsearch_django/tests/test_models.py
@@ -137,6 +137,13 @@ class SearchDocumentMixinTests(TestCase):
             mock.call('bar', 'index', force=False)
         ])
 
+        # test for issue 14 - deletes not being picked up
+        mock_manager.reset_mock()
+        mock_do_search.reset_mock()
+        response = obj.update_search_index(action='delete', index='bar', force=True)
+        mock_manager.in_search_queryset.assert_not_called()
+        mock_do_search.assert_called_once_with('bar', 'delete', force=True)
+
     @mock.patch('elasticsearch_django.models.cache')
     @mock.patch('elasticsearch_django.models.get_client')
     def test__do_search_action(self, mock_client, mock_cache):


### PR DESCRIPTION
Fixes issue #14 - with document deletes never being carried through
because the `in_search_queryset` check always returns False after
an object has been deleted.

FYI the `prune_search_index` management command uses bulk actions
which bypass the `update_search_index` method, so will still work
as expected.