### PR TITLE
Fix null score issue (#18)

### DIFF
--- a/elasticsearch_django/migrations/0001_initial.py
+++ b/elasticsearch_django/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('total_hits', models.IntegerField(default=0, help_text='Total number of matches found for the query (!= the hits returned).')),
                 ('reference', models.CharField(default='', help_text='Custom reference used to identify and group related searches.', max_length=100, blank=True)),
                 ('executed_at', models.DateTimeField(help_text='When the search was executed - set via execute() method.')),
-                ('user', models.ForeignKey(related_name='search_queries', blank=True, to=settings.AUTH_USER_MODEL, help_text='The user who made the search query (nullable).', null=True)),
+                ('user', models.ForeignKey(related_name='search_queries', blank=True, to=settings.AUTH_USER_MODEL, help_text='The user who made the search query (nullable).', null=True, on_delete=models.SET_NULL)),
             ],
         ),
     ]

--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -117,7 +117,7 @@ class SearchDocumentManagerMixin(object):
 
         """
         hits = search_query.hits
-        score_sql = self._raw_sql([(h['id'], h['score']) for h in hits])
+        score_sql = self._raw_sql([(h['id'], h['score'] or 0) for h in hits])
         rank_sql = self._raw_sql([(hits[i]['id'], i) for i in range(len(hits))])
         return (
             self.get_queryset()
@@ -367,7 +367,8 @@ class SearchQuery(models.Model):
         settings.AUTH_USER_MODEL,
         related_name='search_queries',
         blank=True, null=True,
-        help_text="The user who made the search query (nullable)."
+        help_text="The user who made the search query (nullable).",
+        on_delete=models.SET_NULL
     )
     index = models.CharField(
         max_length=100,

--- a/urls.py
+++ b/urls.py
@@ -5,5 +5,5 @@ from django.contrib import admin
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', include(admin.site.urls,)),
 ]


### PR DESCRIPTION
From version 5 of ES, the search API started returning null scores (previously it would return 0). The `from_search_query` method would end up with an invalid SQL statement (passing in `None`). This now converts null scores to zero.

