### PR TITLE
add support for partial updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,8 @@ If the setting ``auto_sync`` is True, then on ``AppConfig.ready`` each model con
 
 There is a **VERY IMPORTANT** caveat to the signal handling. It will **only** pick up on changes to the model itself, and not on related (``ForeignKey``, ``ManyToManyField``) model changes. If the search document is affected by such a change then you will need to implement additional signal handling yourself.
 
+In addtion to ``object.save()``, SeachDocumentMixin also provides the ``update_search_index(self, action, index='_all', update_fields=None, force=False)`` method. Action should be 'index', 'update' or 'delete'. The difference between 'index' and 'update' is that 'update' is a parial update that only changes the fields specified, rather than re-updating the entire document. If ``action`` is 'update' whilst ``update_fields`` is None, action will be changed to ``index``. 
+
 We now have documents in our search index, kept up to date with their Django counterparts. We are ready to start querying ES.
 
 ----

--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ If the setting ``auto_sync`` is True, then on ``AppConfig.ready`` each model con
 
 There is a **VERY IMPORTANT** caveat to the signal handling. It will **only** pick up on changes to the model itself, and not on related (``ForeignKey``, ``ManyToManyField``) model changes. If the search document is affected by such a change then you will need to implement additional signal handling yourself.
 
-In addtion to ``object.save()``, SeachDocumentMixin also provides the ``update_search_index(self, action, index='_all', update_fields=None, force=False)`` method. Action should be 'index', 'update' or 'delete'. The difference between 'index' and 'update' is that 'update' is a parial update that only changes the fields specified, rather than re-updating the entire document. If ``action`` is 'update' whilst ``update_fields`` is None, action will be changed to ``index``. 
+In addition to ``object.save()``, SeachDocumentMixin also provides the ``update_search_index(self, action, index='_all', update_fields=None, force=False)`` method. Action should be 'index', 'update' or 'delete'. The difference between 'index' and 'update' is that 'update' is a partial update that only changes the fields specified, rather than re-updating the entire document. If ``action`` is 'update' whilst ``update_fields`` is None, action will be changed to ``index``. 
 
 We now have documents in our search index, kept up to date with their Django counterparts. We are ready to start querying ES.
 

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -72,7 +72,8 @@ def _connect_signals():
 
 def _on_model_save(sender, **kwargs):
     """Update documents in search index post_save."""
-    _update_search_index(kwargs.get('instance'), 'index')
+    _update_search_index(kwargs.get('instance'), 'index',
+                         update_fields=kwargs.get('update_fields'))
 
 
 def _on_model_delete(sender, **kwargs):
@@ -87,7 +88,7 @@ def _on_model_delete(sender, **kwargs):
     _update_search_index(kwargs.get('instance'), 'delete', force=True)
 
 
-def _update_search_index(instance, action, force=False):
+def _update_search_index(instance, action, update_fields=None, force=False):
     """Process generic search index update actions."""
     # this allows us to turn off sync temporarily - e.g. when doing bulk updates
     if not settings.get_setting('auto_sync'):
@@ -95,6 +96,7 @@ def _update_search_index(instance, action, force=False):
         return
     for index in settings.get_model_indexes(instance.__class__):
         try:
-            instance.update_search_index(action, index=index, force=force)
+            instance.update_search_index(action, index=index,
+                                         update_fields=update_fields, force=force)
         except Exception:
             logger.exception("Error handling '%s' signal for %s", action, instance)

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -94,6 +94,8 @@ def _update_search_index(instance, action, update_fields=None, force=False):
     if not settings.get_setting('auto_sync'):
         logger.debug("SEARCH_AUTO_SYNC disabled, ignoring update.")
         return
+    if action=='index' and update_fields:
+        action = 'update'
     for index in settings.get_model_indexes(instance.__class__):
         try:
             instance.update_search_index(

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -96,7 +96,11 @@ def _update_search_index(instance, action, update_fields=None, force=False):
         return
     for index in settings.get_model_indexes(instance.__class__):
         try:
-            instance.update_search_index(action, index=index,
-                                         update_fields=update_fields, force=force)
+            instance.update_search_index(
+                action,
+                index=index,
+                update_fields=update_fields,
+                force=force
+            )
         except Exception:
             logger.exception("Error handling '%s' signal for %s", action, instance)

--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -283,7 +283,8 @@ class SearchDocumentMixin(object):
             raise ValueError("Object must have a primary key before being indexed.")
         if action == 'update' and not update_fields:
             raise ValueError(
-                "update_fields must be set to a non-empty list of strings when action is 'update'"
+                "update_fields must be set to a non-empty list of strings when action is 'update'."
+                " If you want to do a full update use 'index' instead of 'update'."
             )
 
         if force is True:

--- a/elasticsearch_django/tests/__init__.py
+++ b/elasticsearch_django/tests/__init__.py
@@ -24,5 +24,5 @@ class TestModel(SearchDocumentMixin, models.Model):
 
     objects = TestModelManager()
 
-    def as_search_document(self, index='_all'):
+    def as_search_document(self, index='_all', update_fields=None):
         return SEARCH_DOC

--- a/elasticsearch_django/tests/test_apps.py
+++ b/elasticsearch_django/tests/test_apps.py
@@ -113,7 +113,7 @@ class SearchAppsValidationTests(TestCase):
         """Test the _on_model_save function."""
         obj = SearchDocumentMixin()
         _on_model_save(None, instance=obj)
-        mock_update.assert_called_once_with(obj, 'index')
+        mock_update.assert_called_once_with(obj, 'index', update_fields=None)
 
     @mock.patch('elasticsearch_django.apps.logger')
     @mock.patch('elasticsearch_django.settings.get_model_indexes')
@@ -123,13 +123,13 @@ class SearchAppsValidationTests(TestCase):
         mock_indexes.return_value = ['foo']
         obj = SearchDocumentMixin()
         _update_search_index(obj, 'delete')
-        mock_update.assert_called_once_with('delete', index='foo', force=False)
+        mock_update.assert_called_once_with('delete', index='foo', update_fields=None, force=False)
 
         # if the update bombs, should still pass, and call logger
         mock_update.reset_mock()
         mock_update.side_effect = Exception()
         _update_search_index(obj, 'delete')
-        mock_update.assert_called_once_with('delete', index='foo', force=False)
+        mock_update.assert_called_once_with('delete', index='foo', update_fields=None, force=False)
         mock_logger.exception.assert_called_once()
 
         # check that it calls for each configured index
@@ -138,8 +138,8 @@ class SearchAppsValidationTests(TestCase):
         obj = SearchDocumentMixin()
         _update_search_index(obj, 'delete')
         mock_update.assert_has_calls([
-            mock.call('delete', index='foo', force=False),
-            mock.call('delete', index='bar', force=False)
+            mock.call('delete', index='foo', update_fields=None, force=False),
+            mock.call('delete', index='bar', update_fields=None, force=False)
         ])
 
         # confirm that it is **not** called if auto_sync is off

--- a/elasticsearch_django/tests/test_apps.py
+++ b/elasticsearch_django/tests/test_apps.py
@@ -132,6 +132,11 @@ class SearchAppsValidationTests(TestCase):
         mock_update.assert_called_once_with('delete', index='foo', update_fields=None, force=False)
         mock_logger.exception.assert_called_once()
 
+        # check that if action is 'index' and 'update_fields' is not None, action becomes 'update'
+        mock_update.reset_mock()
+        _update_search_index(obj, 'index', update_fields=['foo'])
+        mock_update.assert_called_once_with('update', index='foo', update_fields=['foo'], force=False)
+
         # check that it calls for each configured index
         mock_update.reset_mock()
         mock_indexes.return_value = ['foo', 'bar']


### PR DESCRIPTION
**What has changed?**
The main change is to the `SearchDocumentMixin._do_search_action` method, which now supports the 'update' action as well as 'index' and 'delete'. The `as_search_document` method will now need to implement this functionality if needed.

**Why has it changed?**
So that if it is known that only one field needs updating there is no need to perform potentially expensive operations generating and sending the whole document, when just a small update is needed. This should improve performance a lot since the search indexes are constantly updated.