### PR TITLE
Allow autosync at model level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ The Django settings for search are contained in a dictionary called ``SEARCH_SET
             # set to True to connect post_save/delete signals
             'auto_sync': True,
             # List of models which will never auto_sync even if auto_sync is True
-            'never_auto_sync': []
+            'never_auto_sync': [],
             # if true, then indexes must have mapping files
             'strict_validation': False
         }

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,8 @@ The Django settings for search are contained in a dictionary called ``SEARCH_SET
             'page_size': 25,
             # set to True to connect post_save/delete signals
             'auto_sync': True,
+            # List of models which will never auto_sync even if auto_sync is True
+            'never_auto_sync': []
             # if true, then indexes must have mapping files
             'strict_validation': False
         }

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -91,6 +91,7 @@ def _update_search_index(instance, action, force=False):
     """Process generic search index update actions."""
     # this allows us to turn off sync temporarily - e.g. when doing bulk updates
     model_name = "{}.{}".format(instance._meta.app_label, instance._meta.model_name)
+    
     if not settings.get_setting('auto_sync'):
         logger.debug("SEARCH_AUTO_SYNC disabled, ignoring update.")
         return
@@ -98,8 +99,7 @@ def _update_search_index(instance, action, force=False):
     if model_name in settings.get_setting('never_auto_sync'):
         logger.debug("Model (%s) listed in never_auto_sync, ignoring update.", model_name)
         return
-        logger.debug("SEARCH_AUTO_SYNC disabled or model listed in never_auto_sync, ignoring update.")
-        return
+
     for index in settings.get_model_indexes(instance.__class__):
         try:
             instance.update_search_index(action, index=index, force=force)

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -91,7 +91,13 @@ def _update_search_index(instance, action, force=False):
     """Process generic search index update actions."""
     # this allows us to turn off sync temporarily - e.g. when doing bulk updates
     model_name = "{}.{}".format(instance._meta.app_label, instance._meta.model_name)
-    if not settings.get_setting('auto_sync') or model_name in settings.get_setting('never_auto_sync'):
+    if not settings.get_setting('auto_sync'):
+        logger.debug("SEARCH_AUTO_SYNC disabled, ignoring update.")
+        return
+
+    if model_name in settings.get_setting('never_auto_sync'):
+        logger.debug("Model (%s) listed in never_auto_sync, ignoring update.", model_name)
+        return
         logger.debug("SEARCH_AUTO_SYNC disabled or model listed in never_auto_sync, ignoring update.")
         return
     for index in settings.get_model_indexes(instance.__class__):

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -90,9 +90,9 @@ def _on_model_delete(sender, **kwargs):
 def _update_search_index(instance, action, force=False):
     """Process generic search index update actions."""
     # this allows us to turn off sync temporarily - e.g. when doing bulk updates
-
-    if not settings.get_setting('auto_sync') or type(instance) in settings.get_setting('never_auto_sync'):
-        logger.debug("SEARCH_AUTO_SYNC disabled, ignoring update.")
+    model_name = "{}.{}".format(instance._meta.app_label, instance._meta.model_name)
+    if not settings.get_setting('auto_sync') or model_name in settings.get_setting('never_auto_sync'):
+        logger.debug("SEARCH_AUTO_SYNC disabled or model listed in never_auto_sync, ignoring update.")
         return
     for index in settings.get_model_indexes(instance.__class__):
         try:

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -90,7 +90,8 @@ def _on_model_delete(sender, **kwargs):
 def _update_search_index(instance, action, force=False):
     """Process generic search index update actions."""
     # this allows us to turn off sync temporarily - e.g. when doing bulk updates
-    if not settings.get_setting('auto_sync'):
+
+    if not settings.get_setting('auto_sync') or type(instance) in settings.get_setting('never_auto_sync'):
         logger.debug("SEARCH_AUTO_SYNC disabled, ignoring update.")
         return
     for index in settings.get_model_indexes(instance.__class__):

--- a/elasticsearch_django/tests/test_apps.py
+++ b/elasticsearch_django/tests/test_apps.py
@@ -121,7 +121,7 @@ class SearchAppsValidationTests(TestCase):
     def test__update_search_index(self, mock_update, mock_indexes, mock_logger):
         """Test the _update_search_index function."""
         mock_indexes.return_value = ['foo']
-        obj = SearchDocumentMixin()
+        obj = TestModel()
         _update_search_index(obj, 'delete')
         mock_update.assert_called_once_with('delete', index='foo', force=False)
 
@@ -135,7 +135,7 @@ class SearchAppsValidationTests(TestCase):
         # check that it calls for each configured index
         mock_update.reset_mock()
         mock_indexes.return_value = ['foo', 'bar']
-        obj = SearchDocumentMixin()
+        obj = TestModel()
         _update_search_index(obj, 'delete')
         mock_update.assert_has_calls([
             mock.call('delete', index='foo', force=False),
@@ -147,4 +147,11 @@ class SearchAppsValidationTests(TestCase):
         with mock.patch('elasticsearch_django.settings.get_setting') as mock_settings:
             mock_settings.return_value = False
             _update_search_index(obj, 'delete', force=True)
+            mock_update.assert_not_called()
+
+        # confirm that it is not called if model is listed in 'never_auto_sync'
+        mock_update.reset_mock()
+        with mock.patch('elasticsearch_django.settings.get_setting') as mock_settings:
+            mock_settings.return_value = ['elasticsearch_django.testmodel']
+            _update_search_index(obj, 'update', force=True)
             mock_update.assert_not_called()

--- a/settings.py
+++ b/settings.py
@@ -157,6 +157,9 @@ SEARCH_SETTINGS = {
         'page_size': 25,
         # set to False to prevent automatic signal connections
         'auto_sync': True,
+        # List of models which will never auto_sync even if auto_sync is True
+        # Use the same app.model format as in 'indexes' above.
+        'never_auto_sync': [],
         # if True, raise ImproperlyConfigured if an index has no mapping file
         'strict_validation': False,
         # path/to/mappings/dir - where mapping files will be expected


### PR DESCRIPTION
**What has changed?**
An extra setting `never_auto_sync` has been added, which allows users to specify which models to never update.

**Why has it changed?**
This allows finer-grained control of the setting `auto_sync` allowing users to turn off auto_sync for certain models without having to turn it off altogether. When `auto_sync` is off, it is important that no models auto-sync which is why this setting is not something like `auto_sync_exceptions`.