### PR TITLE
Issue/24 function to determine if update is necessary

### DIFF
--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -72,7 +72,8 @@ def _connect_signals():
 
 def _on_model_save(sender, **kwargs):
     """Update documents in search index post_save."""
-    _update_search_index(kwargs.get('instance'), 'index')
+    _update_search_index(kwargs.get('instance'), 'index',
+                         update_fields=kwargs.get('update_fields'))
 
 
 def _on_model_delete(sender, **kwargs):
@@ -87,7 +88,7 @@ def _on_model_delete(sender, **kwargs):
     _update_search_index(kwargs.get('instance'), 'delete', force=True)
 
 
-def _update_search_index(instance, action, force=False):
+def _update_search_index(instance, action, update_fields=None, force=False):
     """Process generic search index update actions."""
     # this allows us to turn off sync temporarily - e.g. when doing bulk updates
     if not settings.get_setting('auto_sync'):
@@ -95,6 +96,7 @@ def _update_search_index(instance, action, force=False):
         return
     for index in settings.get_model_indexes(instance.__class__):
         try:
-            instance.update_search_index(action, index=index, force=force)
+            instance.update_search_index(action, index=index,
+                                         update_fields=update_fields, force=force)
         except Exception:
             logger.exception("Error handling '%s' signal for %s", action, instance)

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -96,7 +96,11 @@ def _update_search_index(instance, action, update_fields=None, force=False):
         return
     for index in settings.get_model_indexes(instance.__class__):
         try:
-            instance.update_search_index(action, index=index,
-                                         update_fields=update_fields, force=force)
+            instance.update_search_index(
+                action,
+                index=index,
+                update_fields=update_fields,
+                force=force
+            )
         except Exception:
             logger.exception("Error handling '%s' signal for %s", action, instance)

--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -283,7 +283,8 @@ class SearchDocumentMixin(object):
             raise ValueError("Object must have a primary key before being indexed.")
         if action == 'update' and not update_fields:
             raise ValueError(
-                "update_fields must be set to a non-empty list of strings when action is 'update'"
+                "update_fields must be set to a non-empty list of strings when action is 'update'."
+                " If you want to do a full update use 'index' instead of 'update'."
             )
 
         if force is True:

--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -242,6 +242,25 @@ class SearchDocumentMixin(object):
             id=self.pk
         )
 
+    def is_update_necessary(self, index='_all', update_fields=None):
+        """
+        Check if an update is really needed.
+
+        This method provides the user with the option for custom criterion for
+        when an update is necessary. For example if a field is updated that is
+        not indexed, to avoid an unneccesary update.
+
+        Kwargs:
+            index: string, the name of the index to update. Defaults to '_all',
+                which is a reserved ES term meaning all indexes.
+            update_fields: list of strings, in the case of an 'update' action, it
+                lists which fields should be updated.
+
+        returns bool - if False, update will not happen.
+
+        """
+        return True
+
     def update_search_index(self, action, index='_all', update_fields=None, force=False):
         """
         Update the object in a remote index.
@@ -289,6 +308,11 @@ class SearchDocumentMixin(object):
 
         if force is True:
             logger.debug("Forcing search index update: {} {}".format(action, self))
+        elif (not self.is_update_necessary(index=index, update_fields=update_fields)
+             and action in ('update', 'index')):
+            logger.debug(
+                "No update needed for {}, aborting update".format(self)
+                )
         elif not self.__class__.objects.in_search_queryset(self.pk, index=index):
             logger.debug(
                 "{} is not in the source queryset for '{}', aborting update.".format(self, index)

--- a/elasticsearch_django/tests/__init__.py
+++ b/elasticsearch_django/tests/__init__.py
@@ -24,5 +24,5 @@ class TestModel(SearchDocumentMixin, models.Model):
 
     objects = TestModelManager()
 
-    def as_search_document(self, index='_all'):
+    def as_search_document(self, index='_all', update_fields=None):
         return SEARCH_DOC

--- a/elasticsearch_django/tests/test_apps.py
+++ b/elasticsearch_django/tests/test_apps.py
@@ -113,7 +113,7 @@ class SearchAppsValidationTests(TestCase):
         """Test the _on_model_save function."""
         obj = SearchDocumentMixin()
         _on_model_save(None, instance=obj)
-        mock_update.assert_called_once_with(obj, 'index')
+        mock_update.assert_called_once_with(obj, 'index', update_fields=None)
 
     @mock.patch('elasticsearch_django.apps.logger')
     @mock.patch('elasticsearch_django.settings.get_model_indexes')
@@ -123,13 +123,13 @@ class SearchAppsValidationTests(TestCase):
         mock_indexes.return_value = ['foo']
         obj = SearchDocumentMixin()
         _update_search_index(obj, 'delete')
-        mock_update.assert_called_once_with('delete', index='foo', force=False)
+        mock_update.assert_called_once_with('delete', index='foo', update_fields=None, force=False)
 
         # if the update bombs, should still pass, and call logger
         mock_update.reset_mock()
         mock_update.side_effect = Exception()
         _update_search_index(obj, 'delete')
-        mock_update.assert_called_once_with('delete', index='foo', force=False)
+        mock_update.assert_called_once_with('delete', index='foo', update_fields=None, force=False)
         mock_logger.exception.assert_called_once()
 
         # check that it calls for each configured index
@@ -138,8 +138,8 @@ class SearchAppsValidationTests(TestCase):
         obj = SearchDocumentMixin()
         _update_search_index(obj, 'delete')
         mock_update.assert_has_calls([
-            mock.call('delete', index='foo', force=False),
-            mock.call('delete', index='bar', force=False)
+            mock.call('delete', index='foo', update_fields=None, force=False),
+            mock.call('delete', index='bar', update_fields=None, force=False)
         ])
 
         # confirm that it is **not** called if auto_sync is off

--- a/elasticsearch_django/tests/test_models.py
+++ b/elasticsearch_django/tests/test_models.py
@@ -93,6 +93,12 @@ class SearchDocumentMixinTests(TestCase):
         )
         self.assertEqual(response, mock_get.return_value)
 
+    def test_is_update_necessary(self):
+        """Test the is_update_necessary method."""
+        obj = TestModel()
+        response = obj.is_update_necessary()
+        self.assertEqual(response, True)
+
     @mock.patch('elasticsearch_django.tests.TestModel.objects')
     @mock.patch.object(TestModel, 'search_indexes', new_callable=mock.PropertyMock)
     @mock.patch.object(TestModel, '_do_search_action')
@@ -119,6 +125,14 @@ class SearchDocumentMixinTests(TestCase):
         mock_manager.in_search_queryset.assert_called_once_with(obj.id, index='_all')
         self.assertIsNone(response)
 
+        # check that if is_update_necessary returns false, then update is **not** called
+        mock_manager.reset_mock()
+        obj.is_update_necessary = lambda index, update_fields: False
+        obj.update_search_index(action='index')
+        mock_manager.assert_not_called()
+
+        obj = TestModel()
+        obj.id = 1
         # check that 'index' actions go through as 'index'
         mock_manager.reset_mock()
         mock_do_search.reset_mock()


### PR DESCRIPTION
**What has changed?**
An additional method `is_update_necessary` has been added, that gives a user custom control over when to update or not.

**Why has this changed**
In addition to force, auto_sync and update_fields, this provides another way to only update if strictly necessary. This method however allows a user to provide their own criterion, allowing finer grained control.