### PR TITLE
Issue/27 make changes backwards compatible

### DIFF
--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -25,6 +25,8 @@ class ElasticAppConfig(AppConfig):
             _connect_signals()
         else:
             logger.debug("SEARCH_AUTO_SYNC has been disabled.")
+        if 'never_auto_sync' not in settings.get_settings().keys():
+            settings.set_setting('never_auto_sync', [])
 
 
 def _validate_config(strict=False):

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -92,15 +92,8 @@ def _on_model_delete(sender, **kwargs):
 
 def _update_search_index(instance, action, update_fields=None, force=False):
     """Process generic search index update actions."""
-    # this allows us to turn off sync temporarily - e.g. when doing bulk updates
-    model_name = "{}.{}".format(instance._meta.app_label, instance._meta.model_name)
-    
-    if not settings.get_setting('auto_sync'):
-        logger.debug("SEARCH_AUTO_SYNC disabled, ignoring update.")
-        return
-
-    if model_name in settings.get_setting('never_auto_sync'):
-        logger.debug("Model (%s) listed in never_auto_sync, ignoring update.", model_name)
+    if not settings.auto_sync(instance):
+        logger.debug("Auto sync disabled, ignoring update.")
         return
 
     if action == 'index' and update_fields:

--- a/elasticsearch_django/settings.py
+++ b/elasticsearch_django/settings.py
@@ -32,7 +32,7 @@ def get_setting(key):
 
 
 def set_setting(key, value):
-    """Set specific search setting in Djano conf settings."""
+    """Set specific search setting in Django conf settings."""
     get_settings()[key] = value
 
 

--- a/elasticsearch_django/settings.py
+++ b/elasticsearch_django/settings.py
@@ -30,6 +30,10 @@ def get_setting(key):
     """Return specific search setting from Django conf."""
     return get_settings()[key]
 
+def set_setting(key, value):
+    """Set specific search setting in Djano conf settings."""
+    get_settings()[key] = value
+
 
 def get_connection_string(connection='default'):
     """Return index settings from Django conf."""

--- a/elasticsearch_django/settings.py
+++ b/elasticsearch_django/settings.py
@@ -30,6 +30,7 @@ def get_setting(key):
     """Return specific search setting from Django conf."""
     return get_settings()[key]
 
+
 def set_setting(key, value):
     """Set specific search setting in Djano conf settings."""
     get_settings()[key] = value

--- a/elasticsearch_django/settings.py
+++ b/elasticsearch_django/settings.py
@@ -116,3 +116,14 @@ def get_document_models():
 def get_document_model(index, doc_type):
     """Return dict of index.doc_type: model."""
     return get_document_models().get('%s.%s' % (index, doc_type))
+
+
+def auto_sync(instance):
+    """Returns bool if auto_sync is on for the model (instance)"""
+    # this allows us to turn off sync temporarily - e.g. when doing bulk updates
+    if not get_setting('auto_sync'):
+        return False
+    model_name = "{}.{}".format(instance._meta.app_label, instance._meta.model_name)
+    if model_name in get_setting('never_auto_sync'):
+        return False
+    return True

--- a/elasticsearch_django/tests/test_apps.py
+++ b/elasticsearch_django/tests/test_apps.py
@@ -23,9 +23,11 @@ class SearchAppsConfigTests(TestCase):
     """Tests for the apps module ready function."""
 
     @mock.patch('elasticsearch_django.apps.settings.get_setting')
+    @mock.patch('elasticsearch_django.apps.settings.get_settings')
+    @mock.patch('elasticsearch_django.apps.settings.set_setting')
     @mock.patch('elasticsearch_django.apps._validate_config')
     @mock.patch('elasticsearch_django.apps._connect_signals')
-    def test_ready(self, mock_signals, mock_config, mock_setting):
+    def test_ready(self, mock_signals, mock_config, mock_set_setting, mock_settings, mock_setting):
         """Test the AppConfig.ready method."""
         mock_setting.return_value = True  # auto-sync
         config = ElasticAppConfig('foo_bar', tests)
@@ -39,6 +41,13 @@ class SearchAppsConfigTests(TestCase):
         config.ready()
         mock_config.assert_called_once_with(mock_setting.return_value)
         mock_signals.assert_not_called()
+
+        # check that never_auto_sync property is added if missing
+        mock_set_setting.reset_mock()
+        mock_settings.return_value = {'foo':'bar'}
+        config.ready()
+        mock_set_setting.assert_called_once_with('never_auto_sync', [])
+
 
 
 class SearchAppsValidationTests(TestCase):

--- a/elasticsearch_django/tests/test_apps.py
+++ b/elasticsearch_django/tests/test_apps.py
@@ -156,16 +156,9 @@ class SearchAppsValidationTests(TestCase):
             mock.call('delete', index='bar', update_fields=None, force=False)
         ])
 
-        # confirm that it is **not** called if auto_sync is off
+        # confirm that it is **not** called if auto_sync returns false
         mock_update.reset_mock()
-        with mock.patch('elasticsearch_django.settings.get_setting') as mock_settings:
-            mock_settings.return_value = False
+        with mock.patch('elasticsearch_django.settings.auto_sync') as mock_auto_sync:
+            mock_auto_sync.return_value = False
             _update_search_index(obj, 'delete', force=True)
-            mock_update.assert_not_called()
-
-        # confirm that it is not called if model is listed in 'never_auto_sync'
-        mock_update.reset_mock()
-        with mock.patch('elasticsearch_django.settings.get_setting') as mock_settings:
-            mock_settings.return_value = ['elasticsearch_django.testmodel']
-            _update_search_index(obj, 'update', force=True)
             mock_update.assert_not_called()

--- a/elasticsearch_django/tests/test_settings.py
+++ b/elasticsearch_django/tests/test_settings.py
@@ -14,7 +14,8 @@ from ..settings import (
     get_index_models,
     get_model_indexes,
     get_document_models,
-    get_document_model
+    get_document_model,
+    auto_sync
 )
 from ..tests import TestModel
 
@@ -30,7 +31,9 @@ TEST_SETTINGS = {
         }
     },
     "settings": {
-        "foo": "bar"
+        "foo": "bar",
+        "auto_sync": True,
+        "never_auto_sync": []
     }
 }
 
@@ -109,3 +112,17 @@ class SettingsFunctionTests(TestCase):
     def test_get_document_model(self):
         """Test the get_document_model function."""
         self.assertEqual(get_document_model('baz', 'testmodel'), TestModel)
+
+    @override_settings(SEARCH_SETTINGS=TEST_SETTINGS)
+    def test_auto_sync(self):
+        """Test the auto_sync function."""
+        obj = TestModel()
+        self.assertEqual(auto_sync(obj), True)
+        # Check that if the setting auto_sync is False, the function auto_sync also returns false.
+        TEST_SETTINGS['settings']['auto_sync'] = False
+        self.assertEqual(auto_sync(obj), False)
+        # Check that if a model is in never_auto_sync, then auto_sync returns false
+        TEST_SETTINGS['settings']['auto_sync'] = True
+        TEST_SETTINGS['settings']['never_auto_sync'].append('elasticsearch_django.testmodel')
+        self.assertEqual(auto_sync(obj), False)
+

--- a/elasticsearch_django/tests/test_settings.py
+++ b/elasticsearch_django/tests/test_settings.py
@@ -7,6 +7,7 @@ from ..settings import (
     get_client,
     get_setting,
     get_settings,
+    set_setting,
     get_connection_string,
     get_index_config,
     get_index_names,
@@ -55,6 +56,12 @@ class SettingsFunctionTests(TestCase):
     def test_get_setting(self):
         """Test the get_setting method."""
         self.assertEqual(get_setting('foo'), 'bar')
+
+    @override_settings(SEARCH_SETTINGS=TEST_SETTINGS)
+    def test_set_setting(self):
+        """Test the set_setting method."""
+        set_setting('bar', 'foo')
+        self.assertEqual(TEST_SETTINGS['settings']['bar'], 'foo')
 
     @override_settings(SEARCH_SETTINGS=TEST_SETTINGS)
     def test_get_connection_string(self):


### PR DESCRIPTION
Address issue #30 
**What has changed**
The app will never check if 'never_auto_sync' is in settings, and if it is not, it will add an empty list.

**Why has it changed**
To make changes backwards compatible. At the moment, if a user updates to the latest version without adding 'never_auto_sync' that will cause an error. This addresses that issue.