### PR TITLE
Add function to determine if update is necessary

### DIFF
--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -248,7 +248,7 @@ class SearchDocumentMixin(object):
 
         This method provides the user with the option for custom criterion for
         when an update is necessary. For example if a field is updated that is
-        not indexed, to avoid an unneccesary update.
+        not indexed, to avoid an unnecessary update.
 
         Kwargs:
             index: string, the name of the index to update. Defaults to '_all',


### PR DESCRIPTION
Addresses issue #32 
**What has changed?**
An additional method is_update_necessary has been added, that gives a user custom control over when to update or not.

**Why has this changed**
In addition to force, auto_sync and update_fields, this provides another way to only update if strictly necessary. This method however allows a user to provide their own criterion, allowing finer grained control.
I have assumed this function should only be applied for 'index' and 'update' actions, since if an object is deleted, presumably it should be deleted regardless. I feel like this could lead to unexpected behaviour otherwise.