### PR TITLE
Allow access to original ES response object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ If the setting ``auto_sync`` is True, then on ``AppConfig.ready`` each model con
 
 There is a **VERY IMPORTANT** caveat to the signal handling. It will **only** pick up on changes to the model itself, and not on related (``ForeignKey``, ``ManyToManyField``) model changes. If the search document is affected by such a change then you will need to implement additional signal handling yourself.
 
-In addition to ``object.save()``, SeachDocumentMixin also provides the ``update_search_index(self, action, index='_all', update_fields=None, force=False)`` method. Action should be 'index', 'update' or 'delete'. The difference between 'index' and 'update' is that 'update' is a partial update that only changes the fields specified, rather than re-updating the entire document. If ``action`` is 'update' whilst ``update_fields`` is None, action will be changed to ``index``. 
+In addition to ``object.save()``, SeachDocumentMixin also provides the ``update_search_index(self, action, index='_all', update_fields=None, force=False)`` method. Action should be 'index', 'update' or 'delete'. The difference between 'index' and 'update' is that 'update' is a partial update that only changes the fields specified, rather than re-updating the entire document. If ``action`` is 'update' whilst ``update_fields`` is None, action will be changed to ``index``.
 
 We now have documents in our search index, kept up to date with their Django counterparts. We are ready to start querying ES.
 
@@ -181,6 +181,9 @@ The ``elasticsearch_django.models.SearchQuery`` model wraps this functionality u
     # run a default match_all query
     search = Search(using=get_client(), index='blog')
     sq = execute_search(search)
+    # the raw response is stored on the return object,
+    # but is not stored on the object in the database.
+    print(sq.response)
 
 Calling the ``execute_search`` function will execute the underlying search, log the query JSON, the number of hits, and the list of hit meta information for future analysis. The ``execute`` method also includes these additional kwargs:
 

--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -486,4 +486,5 @@ def execute_search(search, search_terms='', user=None, reference=None, save=True
         executed_at=tz_now(),
         duration=duration
     )
+    log.response = response
     return log.save() if save else log

--- a/elasticsearch_django/tests/test_models.py
+++ b/elasticsearch_django/tests/test_models.py
@@ -237,6 +237,7 @@ class SearchQueryTests(TestCase):
         self.assertEqual(sq.reference, '')
         self.assertTrue(sq.duration > 0)
         self.assertEqual(sq.executed_at, mock_now.return_value)
+        self.assertEqual(sq.response, mock_execute.return_value)
         mock_save.assert_called_once_with()
 
         # try without saving


### PR DESCRIPTION
**What has changed?**
An attribute with the original ES response object, is added to the `SearchQuery` instance in `execute_search`.

**Why has this changed?**
To allow access to response.aggregations and other response fields.
This allows, for example, implementing filtering by facets.