### PR TITLE
Update master branch to ES6 only

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,9 +6,13 @@ verify_ssl = true
 [dev-packages]
 tox = "*"
 coverage = "*"
+black = "*"
 
 [packages]
 elasticsearch-django = {path = ".",editable = true}
 
 [requires]
 python_version = "3.7"
+
+[pipenv]
+allow_prereleases = true

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Elasticsearch for Django
 
 This is a lightweight Django app for people who are using Elasticsearch with Django, and want to manage their indexes.
 
-**NB the master branch is now based on ES5.x. If you are using ES2.x, please switch to the ES2 branch (released on PyPI as 2.x)**
+**NB the master branch is now based on ES6.x. If you are using ES2.x or ES5.x, please switch to the ES2/ES5 branch (released on PyPI as 2.x, 5.x)**
 
 Status
 
@@ -139,7 +139,7 @@ If the setting ``auto_sync`` is True, then on ``AppConfig.ready`` each model con
 
 There is a **VERY IMPORTANT** caveat to the signal handling. It will **only** pick up on changes to the model itself, and not on related (``ForeignKey``, ``ManyToManyField``) model changes. If the search document is affected by such a change then you will need to implement additional signal handling yourself.
 
-In addition to ``object.save()``, SeachDocumentMixin also provides the ``update_search_index(self, action, index='_all', update_fields=None, force=False)`` method. Action should be 'index', 'update' or 'delete'. The difference between 'index' and 'update' is that 'update' is a partial update that only changes the fields specified, rather than re-updating the entire document. If ``action`` is 'update' whilst ``update_fields`` is None, action will be changed to ``index``. 
+In addition to ``object.save()``, SeachDocumentMixin also provides the ``update_search_index(self, action, index='_all', update_fields=None, force=False)`` method. Action should be 'index', 'update' or 'delete'. The difference between 'index' and 'update' is that 'update' is a partial update that only changes the fields specified, rather than re-updating the entire document. If ``action`` is 'update' whilst ``update_fields`` is None, action will be changed to ``index``.
 
 We now have documents in our search index, kept up to date with their Django counterparts. We are ready to start querying ES.
 

--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,7 @@ Elasticsearch for Django
 
 This is a lightweight Django app for people who are using Elasticsearch with Django, and want to manage their indexes.
 
-**NB the master branch is now based on ES6.x. If you are using ES2.x or ES5.x, please switch to the ES2/ES5 branch (released on PyPI as 2.x, 5.x)**
-
-Status
+**NB the master branch is now based on ES6. If you are using ES2/ES5, please switch to the relevant branch (released on PyPI as 2.x, 5.x)**
 
 ----
 
@@ -104,12 +102,69 @@ So far we have configured Django to know the names of the indexes we want, and t
 
 **SearchDocumentMixin**
 
-This mixin must be implemented by the model itself, and it requires a single method implementation - ``as_search_document()``. This should return a dict that is the index representation of the object; the ``index`` kwarg can be used to provide different representations for different indexes. By default this is ``_all`` which means that all indexes receive the same document for a given object.
+This mixin is responsible for the seaerch index document format. We are indexing JSON representations of each object, and we have two methods on the mixin responsible for outputting the correct format - ``as_search_document`` and ``as_search_document_update``.
+
+An aside on the mechanics of the ``auto_sync`` process, which is hooked up using Django's ``post_save`` and ``post_delete`` model signals. ES supports partial updates to documents that already exist, and we make a fundamental assumption about indexing models - that **if you pass the ``update_fields`` kwarg to a ``model.save`` method call, then you are performing a partial update**, and this will be propagated to ES as a partial update only.
+
+To this end, we have two methods for generating the model's JSON representation - ``as_search_document``, which should return a dict that represents the entire object; and ``as_search_document_update``, which takes the ``update_fields`` kwarg, and should return a dict that contains just the fields that are being updated. (NB this is not automated as the field being updated may itself be an object, which needs specific formatting - see below for an example).
+
+To better understand this, let us say that we have a model (``MyModel``) that is configured to be included in an index called ``myindex``. If we save an object, without passing ``update_fields``, then this is considered a full document update, which triggers the object's ``index_search_document`` method:
 
 .. code:: python
 
-    def as_search_document(self, index='_all'):
+    obj = MyModel.objects.first()
+    obj.save()
+    ...
+    # AUTO_SYNC=true will trigger a re-index of the complete object document:
+    obj.index_search_document(index='myindex')
+
+However, if we only want to update a single field (say the ``timestamp``), and we pass this in to the save method, then this will trigger the ``update_search_document`` method, passing in the names of the fields that we want updated.
+
+.. code:: python
+
+    # save a single field on the object
+    obj.save(update_fields=['timestamp'])
+    ...
+    # AUTO_SYNC=true will trigger a partial update of the object document
+    obj.update_search_document(index, update_fields=['timestamp'])
+
+We pass the name of the index being updated as the first arg, as objects may have different representations in different indexes:
+
+.. code:: python
+
+    def as_search_document(self, index):
         return {'name': "foo"} if index == 'foo' else {'name': "bar"}
+
+In the case of the second method, the simplest possible implementation would be a dictionary containing the names of the fields being updated and their new values. However, if the value is itself an object, it will have to serialized properly. As an example:
+
+.. code:: python
+
+    def as_search_document_update(self, index, update_fields):
+        # create a basic attr: value dict from the fields that were updated
+        doc = {f: getattr(self, f) for f in update_fields}
+        # if the 'user' attr was updated, we need to convert this from
+        # a User object to something ES can index - in this case just the full name
+        # (NB GPDR klaxon sounding at this point - do you have permission to do this?)
+        if 'user' in doc:
+            doc['user'] = self.user.get_full_name()
+        return doc
+
+The reason we have split out the update from the full-document index comes from a real problem that we ourselves suffered. The full object representation that we were using was quite DB intensive - we were storing properties of the model that required walking the ORM tree. However, because we were also touching the objects (see below) to record activity timestamps, we ended up flooding the database with queries simply to update a single field in the output document. Partial updates solves this issue:
+
+.. code:: python
+
+    def touch(self):
+        self.timestamp = now()
+        self.save(update_fields=['timestamp'])
+
+    def as_search_document_update(self, index, update_fields):
+        if update_fields == ['timestamp']:
+            # only propagate changes if it's +1hr since the last timestamp change
+            if now() - self.timestamp < timedelta(hours=1):
+                return {}
+            else:
+                return {'timestamp': self.timestamp}
+        ....
 
 **SearchDocumentManagerMixin**
 

--- a/elasticsearch_django/__init__.py
+++ b/elasticsearch_django/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'elasticsearch_django.apps.ElasticAppConfig'
 
-__version__ = '6.0-dev0'
+__version__ = '6.0'

--- a/elasticsearch_django/__init__.py
+++ b/elasticsearch_django/__init__.py
@@ -1,3 +1,3 @@
-default_app_config = 'elasticsearch_django.apps.ElasticAppConfig'
+default_app_config = "elasticsearch_django.apps.ElasticAppConfig"
 
-__version__ = '6.0'
+__version__ = "6.0"

--- a/elasticsearch_django/__init__.py
+++ b/elasticsearch_django/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'elasticsearch_django.apps.ElasticAppConfig'
 
-__version__ = '5.3'
+__version__ = '6.0-dev0'

--- a/elasticsearch_django/admin.py
+++ b/elasticsearch_django/admin.py
@@ -19,12 +19,7 @@ def pprint(data):
     until someone builds a custom syntax function.
 
     """
-    pretty = json.dumps(
-        data,
-        sort_keys=True,
-        indent=4,
-        separators=(',', ': ')
-    )
+    pretty = json.dumps(data, sort_keys=True, indent=4, separators=(",", ": "))
     html = pretty.replace(" ", "&nbsp;").replace("\n", "<br>")
     return mark_safe("<code>%s</code>" % html)
 
@@ -32,39 +27,32 @@ def pprint(data):
 class SearchQueryAdmin(admin.ModelAdmin):
 
     list_display = (
-        'id',
-        'user',
-        'search_terms_',
-        'total_hits',
-        'returned_',
-        'min_',
-        'max_',
-        'reference',
-        'executed_at',
+        "id",
+        "user",
+        "search_terms_",
+        "total_hits",
+        "returned_",
+        "min_",
+        "max_",
+        "reference",
+        "executed_at",
     )
-    list_filter = (
-        'index',
-    )
-    search_fields = (
-        'search_terms',
-        'user__first_name',
-        'user__last_name',
-        'reference'
-    )
+    list_filter = ("index",)
+    search_fields = ("search_terms", "user__first_name", "user__last_name", "reference")
     # excluding because we are using a pretty version instead
-    exclude = ('hits', 'query', 'page')
+    exclude = ("hits", "query", "page")
     readonly_fields = (
-        'user',
-        'index',
-        'search_terms',
-        'total_hits',
-        'returned_',
-        'min_',
-        'max_',
-        'duration',
-        'query_',
-        'hits_',
-        'executed_at',
+        "user",
+        "index",
+        "search_terms",
+        "total_hits",
+        "returned_",
+        "min_",
+        "max_",
+        "duration",
+        "query_",
+        "hits_",
+        "executed_at",
     )
 
     def search_terms_(self, instance):
@@ -79,18 +67,20 @@ class SearchQueryAdmin(admin.ModelAdmin):
 
     def max_(self, instance):
         """Pretty version of max_score."""
-        return '-' if instance.page_size == 0 else instance.max_score
+        return "-" if instance.page_size == 0 else instance.max_score
+
     max_.short_description = "Max score"
 
     def min_(self, instance):
         """Pretty version of min_score."""
-        return '-' if instance.page_size == 0 else instance.min_score
+        return "-" if instance.page_size == 0 else instance.min_score
+
     min_.short_description = "Min score"
 
     def returned_(self, instance):
         """Number of hits returned in the page."""
         if instance.page_size == 0:
-            return '-'
+            return "-"
         else:
             return "%i - %i" % (instance.page_from, instance.page_to)
 
@@ -99,5 +89,6 @@ class SearchQueryAdmin(admin.ModelAdmin):
     def hits_(self, instance):
         """Pretty version of hits JSON."""
         return pprint(instance.hits)
+
 
 admin.site.register(SearchQuery, SearchQueryAdmin)

--- a/elasticsearch_django/index.py
+++ b/elasticsearch_django/index.py
@@ -2,12 +2,7 @@ import logging
 
 from elasticsearch import helpers
 
-from .settings import (
-    get_setting,
-    get_index_mapping,
-    get_index_models,
-    get_client
-)
+from .settings import get_setting, get_index_mapping, get_index_models, get_client
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +22,8 @@ def update_index(index):
     for model in get_index_models(index):
         logger.info("Updating search index model: '%s'", model.search_doc_type)
         objects = model.objects.get_search_queryset(index).iterator()
-        actions = bulk_actions(objects, index=index, action='index')
-        response = helpers.bulk(client, actions, chunk_size=get_setting('chunk_size'))
+        actions = bulk_actions(objects, index=index, action="index")
+        response = helpers.bulk(client, actions, chunk_size=get_setting("chunk_size"))
         responses.append(response)
     return responses
 
@@ -68,11 +63,15 @@ def prune_index(index):
                 prunes.append(obj)
         logger.info(
             "Found %s objects of type '%s' for deletion from '%s'.",
-            len(prunes), model, index
+            len(prunes),
+            model,
+            index,
         )
         if len(prunes) > 0:
-            actions = bulk_actions(prunes, index, 'delete')
-            response = helpers.bulk(client, actions, chunk_size=get_setting('chunk_size'))
+            actions = bulk_actions(prunes, index, "delete")
+            response = helpers.bulk(
+                client, actions, chunk_size=get_setting("chunk_size")
+            )
             responses.append(response)
     return responses
 
@@ -98,18 +97,19 @@ def _prune_hit(hit, model):
         a 'delete' action.
 
     """
-    hit_id = hit['_id']
-    hit_index = hit['_index']
+    hit_id = hit["_id"]
+    hit_index = hit["_index"]
     if model.objects.in_search_queryset(hit_id, index=hit_index):
         logger.debug(
-            "%s with id=%s exists in the '%s' index queryset.",
-            model, hit_id, hit_index
+            "%s with id=%s exists in the '%s' index queryset.", model, hit_id, hit_index
         )
         return None
     else:
         logger.debug(
             "%s with id=%s does not exist in the '%s' index queryset and will be pruned.",
-            model, hit_id, hit_index
+            model,
+            hit_id,
+            hit_index,
         )
         # we don't need the full obj for a delete action, just the id.
         # (the object itself may not even exist.)
@@ -158,7 +158,9 @@ def bulk_actions(objects, index, action):
             how the final document is formatted.
 
     """
-    assert index != '_all', "index arg must be a valid index name. '_all' is a reserved term."
+    assert (
+        index != "_all"
+    ), "index arg must be a valid index name. '_all' is a reserved term."
     logger.info("Creating bulk '%s' actions for '%s'", action, index)
     for obj in objects:
         try:

--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -194,11 +194,13 @@ class SearchDocumentMixin(object):
         )
 
     def as_search_document_update(self, *, index, update_fields):
-        """Return a partial update document based on which fields have been updated.
+        """
+        Return a partial update document based on which fields have been updated.
 
         If an object is saved with the `update_fields` argument passed
         through, then it is assumed that this is a 'partial update'. In
-        this scenario
+        this scenario we need a {property: value} dictionary containing
+        just the fields we want to update.
 
         """
         raise NotImplementedError(

--- a/elasticsearch_django/settings.py
+++ b/elasticsearch_django/settings.py
@@ -16,14 +16,14 @@ from django.conf import settings
 from elasticsearch import Elasticsearch
 
 
-def get_client(connection='default'):
+def get_client(connection="default"):
     """Return configured elasticsearch client."""
     return Elasticsearch(get_connection_string(connection))
 
 
 def get_settings():
     """Return settings from Django conf."""
-    return settings.SEARCH_SETTINGS['settings']
+    return settings.SEARCH_SETTINGS["settings"]
 
 
 def get_setting(key, *default):
@@ -39,19 +39,19 @@ def set_setting(key, value):
     get_settings()[key] = value
 
 
-def get_connection_string(connection='default'):
+def get_connection_string(connection="default"):
     """Return index settings from Django conf."""
-    return settings.SEARCH_SETTINGS['connections'][connection]
+    return settings.SEARCH_SETTINGS["connections"][connection]
 
 
 def get_index_config(index):
     """Return index settings from Django conf."""
-    return settings.SEARCH_SETTINGS['indexes'][index]
+    return settings.SEARCH_SETTINGS["indexes"][index]
 
 
 def get_index_names():
     """Return list of the names of all configured indexes."""
-    return list(settings.SEARCH_SETTINGS['indexes'].keys())
+    return list(settings.SEARCH_SETTINGS["indexes"].keys())
 
 
 def get_index_mapping(index):
@@ -65,10 +65,10 @@ def get_index_mapping(index):
 
     """
     # app_path = apps.get_app_config('elasticsearch_django').path
-    mappings_dir = get_setting('mappings_dir')
-    filename = '%s.json' % index
+    mappings_dir = get_setting("mappings_dir")
+    filename = "%s.json" % index
     path = os.path.join(mappings_dir, filename)
-    with open(path, 'r') as f:
+    with open(path, "r") as f:
         return json.load(f)
 
 
@@ -80,8 +80,8 @@ def get_index_models(index):
 
     """
     models = []
-    for app_model in get_index_config(index).get('models'):
-        app, model = app_model.split('.')
+    for app_model in get_index_config(index).get("models"):
+        app, model = app_model.split(".")
         models.append(apps.get_model(app, model))
     return models
 
@@ -111,22 +111,22 @@ def get_document_models():
     mappings = {}
     for i in get_index_names():
         for m in get_index_models(i):
-            key = '%s.%s' % (i, m._meta.model_name)
+            key = "%s.%s" % (i, m._meta.model_name)
             mappings[key] = m
     return mappings
 
 
 def get_document_model(index, doc_type):
     """Return dict of index.doc_type: model."""
-    return get_document_models().get('%s.%s' % (index, doc_type))
+    return get_document_models().get("%s.%s" % (index, doc_type))
 
 
 def auto_sync(instance):
     """Returns bool if auto_sync is on for the model (instance)"""
     # this allows us to turn off sync temporarily - e.g. when doing bulk updates
-    if not get_setting('auto_sync'):
+    if not get_setting("auto_sync"):
         return False
     model_name = "{}.{}".format(instance._meta.app_label, instance._meta.model_name)
-    if model_name in get_setting('never_auto_sync', []):
+    if model_name in get_setting("never_auto_sync", []):
         return False
     return True

--- a/elasticsearch_django/tests/__init__.py
+++ b/elasticsearch_django/tests/__init__.py
@@ -24,5 +24,8 @@ class TestModel(SearchDocumentMixin, models.Model):
 
     objects = TestModelManager()
 
-    def as_search_document(self, index='_all', update_fields=None):
+    def as_search_document(self, index):
+        return SEARCH_DOC
+
+    def as_search_document_update(self, index, update_fields):
         return SEARCH_DOC

--- a/elasticsearch_django/tests/test_apps.py
+++ b/elasticsearch_django/tests/test_apps.py
@@ -22,14 +22,14 @@ class SearchAppsConfigTests(TestCase):
 
     """Tests for the apps module ready function."""
 
-    @mock.patch('elasticsearch_django.apps.settings.get_setting')
-    @mock.patch('elasticsearch_django.apps.settings.get_settings')
-    @mock.patch('elasticsearch_django.apps._validate_config')
-    @mock.patch('elasticsearch_django.apps._connect_signals')
+    @mock.patch("elasticsearch_django.apps.settings.get_setting")
+    @mock.patch("elasticsearch_django.apps.settings.get_settings")
+    @mock.patch("elasticsearch_django.apps._validate_config")
+    @mock.patch("elasticsearch_django.apps._connect_signals")
     def test_ready(self, mock_signals, mock_config, mock_settings, mock_setting):
         """Test the AppConfig.ready method."""
         mock_setting.return_value = True  # auto-sync
-        config = ElasticAppConfig('foo_bar', tests)
+        config = ElasticAppConfig("foo_bar", tests)
         config.ready()
         mock_config.assert_called_once_with(mock_setting.return_value)
         mock_signals.assert_called_once_with()
@@ -49,99 +49,103 @@ class SearchAppsValidationTests(TestCase):
     def test__validate_model(self):
         """Test _validate_model function."""
         # 1. model doesn't implement as_search_document
-        with mock.patch('elasticsearch_django.tests.test_apps.TestModel') as tm:
+        with mock.patch("elasticsearch_django.tests.test_apps.TestModel") as tm:
             del tm.as_search_document
             self.assertRaises(ImproperlyConfigured, _validate_model, tm)
 
         # 2. model.objects doesn't implement get_search_queryset
-        with mock.patch('elasticsearch_django.tests.test_apps.TestModel') as tm:
+        with mock.patch("elasticsearch_django.tests.test_apps.TestModel") as tm:
             del tm.objects.get_search_queryset
             self.assertRaises(ImproperlyConfigured, _validate_model, tm)
 
         # model should pass
-        with mock.patch('elasticsearch_django.tests.test_apps.TestModel') as tm:
+        with mock.patch("elasticsearch_django.tests.test_apps.TestModel") as tm:
             _validate_model(tm)
 
-    @mock.patch('elasticsearch_django.apps.settings')
+    @mock.patch("elasticsearch_django.apps.settings")
     def test__validate_mapping(self, mock_settings):
         """Test _validate_model function."""
-        _validate_mapping('foo', strict=True)
-        mock_settings.get_index_mapping.assert_called_once_with('foo')
+        _validate_mapping("foo", strict=True)
+        mock_settings.get_index_mapping.assert_called_once_with("foo")
         mock_settings.get_index_mapping.side_effect = IOError()
-        self.assertRaises(ImproperlyConfigured, _validate_mapping, 'foo', strict=True)
+        self.assertRaises(ImproperlyConfigured, _validate_mapping, "foo", strict=True)
         # shouldn't raise error
-        _validate_mapping('foo', strict=False)
+        _validate_mapping("foo", strict=False)
 
-    @mock.patch('elasticsearch_django.apps.settings')
-    @mock.patch('elasticsearch_django.apps._validate_model')
-    @mock.patch('elasticsearch_django.apps._validate_mapping')
+    @mock.patch("elasticsearch_django.apps.settings")
+    @mock.patch("elasticsearch_django.apps._validate_model")
+    @mock.patch("elasticsearch_django.apps._validate_mapping")
     def test__validate_config(self, mock_mapping, mock_model, mock_settings):
         """Test _validate_model function."""
-        mock_settings.get_index_names.return_value = ['foo']
+        mock_settings.get_index_names.return_value = ["foo"]
         mock_settings.get_index_models.return_value = [TestModel]
         _validate_config()
-        mock_mapping.assert_called_once_with('foo', strict=False)
+        mock_mapping.assert_called_once_with("foo", strict=False)
         mock_model.assert_called_once_with(TestModel)
 
-    @mock.patch('elasticsearch_django.apps.signals')
-    @mock.patch('elasticsearch_django.apps.settings')
+    @mock.patch("elasticsearch_django.apps.signals")
+    @mock.patch("elasticsearch_django.apps.settings")
     def test__connect_signals(self, mock_settings, mock_signals):
         """Test the _connect_signals function."""
         # this should connect up the signals once, for TestModel
-        mock_settings.get_index_names.return_value = ['foo']
+        mock_settings.get_index_names.return_value = ["foo"]
         mock_settings.get_index_models.return_value = [TestModel]
         _connect_signals()
         mock_signals.post_save.connect.assert_called_once_with(
-            _on_model_save,
-            sender=TestModel,
-            dispatch_uid='testmodel.post_save'
+            _on_model_save, sender=TestModel, dispatch_uid="testmodel.post_save"
         )
         mock_signals.post_delete.connect.assert_called_once_with(
-            _on_model_delete,
-            sender=TestModel,
-            dispatch_uid='testmodel.post_delete'
+            _on_model_delete, sender=TestModel, dispatch_uid="testmodel.post_delete"
         )
 
-    @mock.patch.object(SearchDocumentMixin, 'search_indexes', ['foo'])
-    @mock.patch.object(SearchDocumentMixin, 'delete_search_document')
+    @mock.patch.object(SearchDocumentMixin, "search_indexes", ["foo"])
+    @mock.patch.object(SearchDocumentMixin, "delete_search_document")
     def test__on_model_delete(self, mock_delete):
         """Test the _on_model_delete function."""
         obj = SearchDocumentMixin()
         _on_model_delete(None, instance=obj)
-        mock_delete.assert_called_once_with(index='foo')
+        mock_delete.assert_called_once_with(index="foo")
 
-    @mock.patch.object(SearchDocumentMixin, 'search_indexes', ['foo', 'bar'])
-    @mock.patch.object(SearchDocumentMixin, 'delete_search_document')
+    @mock.patch.object(SearchDocumentMixin, "search_indexes", ["foo", "bar"])
+    @mock.patch.object(SearchDocumentMixin, "delete_search_document")
     def test__on_model_delete__multiple_indexes(self, mock_delete):
         """Test the _on_model_delete function with multiple indexes."""
         obj = SearchDocumentMixin()
         _on_model_delete(None, instance=obj)
         self.assertEqual(mock_delete.call_count, 2)
 
-    @mock.patch('elasticsearch_django.apps._update_search_index')
+    @mock.patch("elasticsearch_django.apps._update_search_index")
     def test__on_model_save__index(self, mock_update):
         """Test the _on_model_save function without update_fields."""
-        obj = mock.Mock(spec=SearchDocumentMixin, search_indexes=['foo'])
+        obj = mock.Mock(spec=SearchDocumentMixin, search_indexes=["foo"])
         _on_model_save(None, instance=obj, update_fields=None)
-        mock_update.assert_called_once_with(instance=obj, index='foo', update_fields=None)
+        mock_update.assert_called_once_with(
+            instance=obj, index="foo", update_fields=None
+        )
 
-    @mock.patch('elasticsearch_django.apps._update_search_index')
+    @mock.patch("elasticsearch_django.apps._update_search_index")
     def test__on_model_save__update(self, mock_update):
         """Test the _on_model_save function without update_fields."""
-        obj = mock.Mock(spec=SearchDocumentMixin, search_indexes=['foo'])
-        _on_model_save(None, instance=obj, update_fields=['bar'])
-        mock_update.assert_called_once_with(instance=obj, index='foo', update_fields=['bar'])
+        obj = mock.Mock(spec=SearchDocumentMixin, search_indexes=["foo"])
+        _on_model_save(None, instance=obj, update_fields=["bar"])
+        mock_update.assert_called_once_with(
+            instance=obj, index="foo", update_fields=["bar"]
+        )
 
     def test__update_search_index(self):
         """Test the _update_search_index function with an index action."""
         obj = mock.Mock(spec=SearchDocumentMixin)
-        _update_search_index(instance=obj, index='foo', update_fields=None)
+        _update_search_index(instance=obj, index="foo", update_fields=None)
         self.assertEqual(obj.index_search_document.call_count, 1)
         self.assertEqual(obj.update_search_document.call_count, 0)
+        obj.index_search_document.assert_called_once_with(index="foo")
 
     def test__update_search_update(self):
         """Test the _update_search_index function with an update action."""
         obj = mock.Mock(spec=SearchDocumentMixin)
-        _update_search_index(instance=obj, index='foo', update_fields=['bar'])
+        _update_search_index(instance=obj, index="foo", update_fields=["bar"])
         self.assertEqual(obj.update_search_document.call_count, 1)
         self.assertEqual(obj.index_search_document.call_count, 0)
+        obj.update_search_document.assert_called_once_with(
+            index="foo", update_fields=["bar"]
+        )

--- a/elasticsearch_django/tests/test_models.py
+++ b/elasticsearch_django/tests/test_models.py
@@ -35,7 +35,12 @@ class SearchDocumentMixinTests(TestCase):
     def test_as_search_document(self):
         """Test the as_search_document method."""
         obj = SearchDocumentMixin()
-        self.assertRaises(NotImplementedError, obj.as_search_document)
+        self.assertRaises(NotImplementedError, obj.as_search_document, index='_all')
+
+    def test_as_search_document_update(self):
+        """Test the as_search_document_update method."""
+        obj = SearchDocumentMixin()
+        self.assertRaises(NotImplementedError, obj.as_search_document_update, index='_all', update_fields=[])
 
     @mock.patch('elasticsearch_django.settings.get_connection_string', lambda: 'http://testserver')
     @mock.patch('elasticsearch_django.models.get_client')

--- a/elasticsearch_django/utils.py
+++ b/elasticsearch_django/utils.py
@@ -17,7 +17,7 @@ def disable_search_updates():
 
     """
     _settings = get_settings()
-    _sync = _settings['auto_sync']
-    _settings['auto_sync'] = False
+    _sync = _settings["auto_sync"]
+    _settings["auto_sync"] = False
     yield
-    _settings['auto_sync'] = _sync
+    _settings["auto_sync"] = _sync

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Django>=1.11',
-        'elasticsearch>=5,<6',
-        'elasticsearch-dsl>=5,<6',
+        'elasticsearch>=6,<7',
+        'elasticsearch-dsl>=6,<7',
         'psycopg2-binary>=2.6',
         'simplejson>=3.8'
     ],


### PR DESCRIPTION
This PR will update the master branch to require ES6 and above. It formally deprecates ES5 and ES2, which will now live on in named branches only. Aside from documentation, and updating the dependency versions, this PR also create a separate code path for partial document updates, so that instead of a single `as_search_document` method that takes an optional `update_fields` kwarg, we have two separate methods, `as_search_document` and `as_search_document_update`. Only the later has the `update_fields` arg, which is mandatory. There are examples in the README, so recommendation is to start there.

One other addition is that the repo has been "Blackened" - so the formatting of app *.py files should now be consistent.
