### PR TITLE
Add pre_index, update, delete, signals

### DIFF
--- a/elasticsearch_django/__init__.py
+++ b/elasticsearch_django/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = "elasticsearch_django.apps.ElasticAppConfig"
 
-__version__ = "6.2"
+__version__ = "6.3"

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -22,10 +22,7 @@ class ElasticAppConfig(AppConfig):
         """Validate config and connect signals."""
         super(ElasticAppConfig, self).ready()
         _validate_config(settings.get_setting("strict_validation"))
-        if settings.get_setting("auto_sync"):
-            _connect_signals()
-        else:
-            logger.debug("SEARCH_AUTO_SYNC has been disabled.")
+        _connect_signals()
 
 
 def _validate_config(strict=False):

--- a/elasticsearch_django/apps.py
+++ b/elasticsearch_django/apps.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models import signals
 
 from . import settings
+from .signals import pre_index, pre_update, pre_delete
 
 logger = logging.getLogger(__name__)
 
@@ -69,56 +70,63 @@ def _connect_signals():
 
 def _connect_model_signals(model):
     """Connect signals for a single model."""
-    if settings.auto_sync(model):
-        dispatch_uid = "%s.post_save" % model._meta.model_name
-        logger.debug("Connecting search index model sync signal: %s", dispatch_uid)
-        signals.post_save.connect(
-            _on_model_save, sender=model, dispatch_uid=dispatch_uid
-        )
-        dispatch_uid = "%s.post_delete" % model._meta.model_name
-        logger.debug("Connecting search index model sync signal: %s", dispatch_uid)
-        signals.post_delete.connect(
-            _on_model_delete, sender=model, dispatch_uid=dispatch_uid
-        )
-    else:
-        logger.debug(
-            "Auto sync disabled for '%s', ignoring update.", model._meta.model_name
-        )
+    dispatch_uid = "%s.post_save" % model._meta.model_name
+    logger.debug("Connecting search index model post_save signal: %s", dispatch_uid)
+    signals.post_save.connect(_on_model_save, sender=model, dispatch_uid=dispatch_uid)
+    dispatch_uid = "%s.post_delete" % model._meta.model_name
+    logger.debug("Connecting search index model post_delete signal: %s", dispatch_uid)
+    signals.post_delete.connect(
+        _on_model_delete, sender=model, dispatch_uid=dispatch_uid
+    )
 
 
 def _on_model_save(sender, **kwargs):
     """Update document in search index post_save."""
-    update_fields = kwargs["update_fields"]
-    instance = kwargs["instance"]
+    instance = kwargs.pop("instance")
+    update_fields = kwargs.pop("update_fields")
     for index in instance.search_indexes:
-        _update_search_index(
-            instance=instance, index=index, update_fields=update_fields
-        )
+        try:
+            _update_search_index(
+                instance=instance, index=index, update_fields=update_fields
+            )
+        except Exception:
+            logger.exception("Error handling 'on_save' signal for %s", instance)
+
+
+def _on_model_delete(sender, **kwargs):
+    """Remove documents from search indexes post_delete."""
+    instance = kwargs.pop("instance")
+    for index in instance.search_indexes:
+        try:
+            _delete_from_search_index(instance=instance, index=index)
+        except Exception:
+            logger.exception("Error handling 'on_delete' signal for %s", instance)
 
 
 def _update_search_index(*, instance, index, update_fields):
     """Process index / update search index update actions."""
     try:
         if update_fields:
-            instance.update_search_document(index=index, update_fields=update_fields)
+            pre_update.send(
+                sender=instance.__class__,
+                instance=instance,
+                index=index,
+                update_fields=update_fields,
+            )
+            if settings.auto_sync(instance):
+                instance.update_search_document(
+                    index=index, update_fields=update_fields
+                )
         else:
-            instance.index_search_document(index=index)
+            pre_index.send(sender=instance.__class__, instance=instance, index=index)
+            if settings.auto_sync(instance):
+                instance.index_search_document(index=index)
     except Exception:
         logger.exception("Error handling 'post_save' signal for %s", instance)
 
 
-def _on_model_delete(sender, **kwargs):
-    """
-    Remove documents from search index post_delete.
-
-    When deleting a document from the search index, always use force=True
-    to ignore the in_search_queryset check - as by definition on a delete
-    the object will no longer in exist in the database.
-
-    """
-    instance = kwargs["instance"]
-    for index in instance.search_indexes:
-        try:
-            instance.delete_search_document(index=index)
-        except Exception:
-            logger.exception("Error handling 'on_delete' signal for %s", instance)
+def _delete_from_search_index(*, instance, index):
+    """Remove a document from a search index."""
+    pre_delete.send(sender=instance.__class__, instance=instance, index=index)
+    if settings.auto_sync(instance):
+        instance.delete_search_document(index=index)

--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -25,18 +25,6 @@ UPDATE_STRATEGY_PARTIAL = "partial"
 UPDATE_STRATEGY = get_setting("update_strategy", UPDATE_STRATEGY_FULL)
 
 
-class InvalidUpdateFields(Exception):
-    """Custom exception raised when passing model fields to the
-    save method as 'update_fields' that cannot be simply serialized."""
-
-    def __init__(self, invalid_fields):
-        message = (
-            f"Unserializable update_fields value - please override "
-            f"as_search_document_update: {invalid_fields}"
-        )
-        super().__init__(message)
-
-
 class SearchDocumentManagerMixin(object):
 
     """

--- a/elasticsearch_django/signals.py
+++ b/elasticsearch_django/signals.py
@@ -1,0 +1,12 @@
+import django.dispatch
+
+# signal fired just before calling model.index_search_document
+pre_index = django.dispatch.Signal(providing_args=["instance", "index"])
+
+# signal fired just before calling model.update_search_document
+pre_update = django.dispatch.Signal(
+    providing_args=["instance", "index", "update_fields"]
+)
+
+# signal fired just before calling model.delete_search_document
+pre_delete = django.dispatch.Signal(providing_args=["instance", "index"])

--- a/elasticsearch_django/tests/test_apps.py
+++ b/elasticsearch_django/tests/test_apps.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 
 from ..apps import (
     ElasticAppConfig,
+    _delete_from_search_index,
     _validate_config,
     _validate_model,
     _validate_mapping,
@@ -111,21 +112,40 @@ class SearchAppsValidationTests(TestCase):
             _on_model_delete, sender=TestModel, dispatch_uid="testmodel.post_delete"
         )
 
-    @mock.patch.object(SearchDocumentMixin, "search_indexes", ["foo"])
-    @mock.patch.object(SearchDocumentMixin, "delete_search_document")
+    @mock.patch('elasticsearch_django.apps._delete_from_search_index')
     def test__on_model_delete(self, mock_delete):
         """Test the _on_model_delete function."""
-        obj = SearchDocumentMixin()
-        _on_model_delete(None, instance=obj)
-        mock_delete.assert_called_once_with(index="foo")
-
-    @mock.patch.object(SearchDocumentMixin, "search_indexes", ["foo", "bar"])
-    @mock.patch.object(SearchDocumentMixin, "delete_search_document")
-    def test__on_model_delete__multiple_indexes(self, mock_delete):
-        """Test the _on_model_delete function with multiple indexes."""
-        obj = SearchDocumentMixin()
+        obj = mock.Mock(spec=SearchDocumentMixin, search_indexes=["foo", "bar"])
         _on_model_delete(None, instance=obj)
         self.assertEqual(mock_delete.call_count, 2)
+        mock_delete.assert_called_with(
+            instance=obj,
+            index="bar"
+        )
+
+    @mock.patch("elasticsearch_django.apps.settings.auto_sync")
+    @mock.patch("elasticsearch_django.apps.pre_delete")
+    def test__delete_from_search_index_True(self, mock_delete_signal, mock_auto_sync):
+        """Test the _delete_from_search_index function when AUTO_SYNC=True."""
+        mock_auto_sync.return_value = True
+        obj = mock.Mock(spec=SearchDocumentMixin)
+        _delete_from_search_index(instance=obj, index="foo")
+        mock_delete_signal.send.assert_called_once_with(
+            sender=obj.__class__, instance=obj, index="foo"
+        )
+        obj.delete_search_document.assert_called_once_with(index="foo")
+
+    @mock.patch("elasticsearch_django.apps.settings.auto_sync")
+    @mock.patch("elasticsearch_django.apps.pre_delete")
+    def test__delete_from_search_index_False(self, mock_delete_signal, mock_auto_sync):
+        """Test the _delete_from_search_index function when AUTO_SYNC=False."""
+        obj = mock.Mock(spec=SearchDocumentMixin)
+        mock_auto_sync.return_value = False
+        _delete_from_search_index(instance=obj, index="foo")
+        mock_delete_signal.send.assert_called_once_with(
+            sender=obj.__class__, instance=obj, index="foo"
+        )
+        obj.delete_search_document.assert_not_called()
 
     @mock.patch("elasticsearch_django.apps._update_search_index")
     def test__on_model_save__index(self, mock_update):
@@ -145,20 +165,26 @@ class SearchAppsValidationTests(TestCase):
             instance=obj, index="foo", update_fields=["bar"]
         )
 
-    def test__update_search_index(self):
+    @mock.patch("elasticsearch_django.apps.settings.auto_sync")
+    def test__update_search_index_True(self, mock_auto_sync):
         """Test the _update_search_index function with an index action."""
+        mock_auto_sync.return_value = True
         obj = mock.Mock(spec=SearchDocumentMixin)
         _update_search_index(instance=obj, index="foo", update_fields=None)
         self.assertEqual(obj.index_search_document.call_count, 1)
         self.assertEqual(obj.update_search_document.call_count, 0)
         obj.index_search_document.assert_called_once_with(index="foo")
+        obj.update_search_document.assert_not_called()
+        obj.delete_search_document.assert_not_called()
 
-    def test__update_search_update(self):
-        """Test the _update_search_index function with an update action."""
+    @mock.patch("elasticsearch_django.apps.settings.auto_sync")
+    def test__update_search_index_False(self, mock_auto_sync):
+        """Test the _update_search_index function with an index action."""
+        mock_auto_sync.return_value = False
         obj = mock.Mock(spec=SearchDocumentMixin)
-        _update_search_index(instance=obj, index="foo", update_fields=["bar"])
-        self.assertEqual(obj.update_search_document.call_count, 1)
+        _update_search_index(instance=obj, index="foo", update_fields=None)
         self.assertEqual(obj.index_search_document.call_count, 0)
-        obj.update_search_document.assert_called_once_with(
-            index="foo", update_fields=["bar"]
-        )
+        self.assertEqual(obj.update_search_document.call_count, 0)
+        obj.index_search_document.assert_not_called()
+        obj.update_search_document.assert_not_called()
+        obj.delete_search_document.assert_not_called()

--- a/elasticsearch_django/tests/test_apps.py
+++ b/elasticsearch_django/tests/test_apps.py
@@ -24,24 +24,14 @@ class SearchAppsConfigTests(TestCase):
     """Tests for the apps module ready function."""
 
     @mock.patch("elasticsearch_django.apps.settings.get_setting")
-    @mock.patch("elasticsearch_django.apps.settings.get_settings")
     @mock.patch("elasticsearch_django.apps._validate_config")
     @mock.patch("elasticsearch_django.apps._connect_signals")
-    def test_ready(self, mock_signals, mock_config, mock_settings, mock_setting):
+    def test_ready(self, mock_signals, mock_config, mock_setting):
         """Test the AppConfig.ready method."""
-        mock_setting.return_value = True  # auto-sync
         config = ElasticAppConfig("foo_bar", tests)
         config.ready()
         mock_config.assert_called_once_with(mock_setting.return_value)
         mock_signals.assert_called_once_with()
-
-        mock_setting.return_value = False  # auto-sync
-        mock_signals.reset_mock()
-        mock_config.reset_mock()
-        config.ready()
-        mock_config.assert_called_once_with(mock_setting.return_value)
-        mock_signals.assert_not_called()
-
 
 class SearchAppsValidationTests(TestCase):
 

--- a/elasticsearch_django/tests/test_models.py
+++ b/elasticsearch_django/tests/test_models.py
@@ -9,7 +9,6 @@ from django.utils.timezone import now as tz_now
 from elasticsearch_dsl.search import Search
 
 from ..models import (
-    InvalidUpdateFields,
     SearchDocumentMixin,
     SearchDocumentManagerMixin,
     SearchQuery,


### PR DESCRIPTION
This allows for fine-grained control over the indexing of documents, and also for async updates.