### PR TITLE
Add support for ArrayField

### DIFF
--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -171,6 +171,7 @@ class SearchDocumentMixin(object):
     # a known format. All other types will need custom serialization.
     # Used by as_search_document_update method
     SIMPLE_UPDATE_FIELD_TYPES = [
+        "ArrayField",
         "AutoField",
         "BooleanField",
         "CharField",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "elasticsearch-django"
-version = "7.1.1"
+version = "7.1.2"
 description = "Elasticsearch Django app."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]


### PR DESCRIPTION
This commit adds ArrayField as a simple serializable type - as it can be serialized as a list.