### PR TITLE
Add support for db alias

### DIFF
--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -135,11 +135,27 @@ class SearchDocumentManagerMixin(models.Manager):
     Model manager mixin that adds search document methods.
 
     There is one method in this class that must implemented -
-    `get_search_queryset`. This must return a queryset that is the
-    set of objects to be indexed. This queryset is then converted
-    into a generator that emits the objects as JSON documents.
+    `get_search_queryset`. This must return a queryset that is the set
+    of objects to be indexed. This queryset is then converted into a
+    generator that emits the objects as JSON documents.
+
+    If you are using a different database connection for the
+    `get_search_queryset` method from the one that you use to save
+    models (default) you may run into a situation where the
+    `in_search_queryset` method returns False for an object that has
+    been created because the `get_search_queryset` query runs in a
+    different transaction from the one that created the object, and
+    cannot 'see' the object until the transaction has committed.
+
+    To avoid this, you can set the `ON_MODEL_SAVE_DB_ALIAS` attribute
+    to force `in_search_queryset` to use the same database connection
+    as that used to create the object.
+
+    Edge case, but it does happen.
 
     """
+
+    ON_MODEL_SAVE_DB_ALIAS: str = ""
 
     def get_search_queryset(self, index: str = "_all") -> QuerySet:
         """
@@ -181,7 +197,10 @@ class SearchDocumentManagerMixin(models.Manager):
                 Defaults to '_all'.
 
         """
-        return self.get_search_queryset(index=index).filter(pk=instance_pk).exists()
+        qs = self.get_search_queryset(index=index).filter(pk=instance_pk)
+        if alias := self.ON_MODEL_SAVE_DB_ALIAS:
+            qs = qs.using(alias)
+        return qs.exists()
 
 
 class SearchDocumentMixin:

--- a/elasticsearch_django/models.py
+++ b/elasticsearch_django/models.py
@@ -141,21 +141,20 @@ class SearchDocumentManagerMixin(models.Manager):
 
     If you are using a different database connection for the
     `get_search_queryset` method from the one that you use to save
-    models (default) you may run into a situation where the
-    `in_search_queryset` method returns False for an object that has
-    been created because the `get_search_queryset` query runs in a
-    different transaction from the one that created the object, and
-    cannot 'see' the object until the transaction has committed.
+    models you may run into a situation where the `in_search_queryset`
+    method returns False for an object that has been created because the
+    `get_search_queryset` query runs in a different transaction from the
+    one that created the object.
 
-    To avoid this, you can set the `ON_MODEL_SAVE_DB_ALIAS` attribute
-    to force `in_search_queryset` to use the same database connection
-    as that used to create the object.
+    To avoid this, you can set the `IN_SEARCH_QUERYSET_DB_ALIAS`
+    settings to force `in_search_queryset` to use the same database
+    connection as that used to create the object.
 
     Edge case, but it does happen.
 
     """
 
-    ON_MODEL_SAVE_DB_ALIAS: str = ""
+    IN_SEARCH_QUERYSET_DB_ALIAS = get_setting("in_search_queryset_db_alias")
 
     def get_search_queryset(self, index: str = "_all") -> QuerySet:
         """
@@ -198,7 +197,7 @@ class SearchDocumentManagerMixin(models.Manager):
 
         """
         qs = self.get_search_queryset(index=index).filter(pk=instance_pk)
-        if alias := self.ON_MODEL_SAVE_DB_ALIAS:
+        if alias := self.IN_SEARCH_QUERYSET_DB_ALIAS:
             qs = qs.using(alias)
         return qs.exists()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django = "^3.2 || ^4.0"
+django = "^3.2 || ^4.0 || ^5.0"
 elasticsearch = "^8.0"
 simplejson = "*"
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -15,8 +15,6 @@ class ExampleModelQuerySet(SearchResultsQuerySet):
 
 
 class ExampleModelManager(SearchDocumentManagerMixin, models.Manager):
-    ON_MODEL_SAVE_DB_ALIAS = "direct"
-
     def get_search_queryset(self, index="_all"):
         return self.all()
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -15,6 +15,8 @@ class ExampleModelQuerySet(SearchResultsQuerySet):
 
 
 class ExampleModelManager(SearchDocumentManagerMixin, models.Manager):
+    ON_MODEL_SAVE_DB_ALIAS = "direct"
+
     def get_search_queryset(self, index="_all"):
         return self.all()
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -160,6 +160,8 @@ SEARCH_SETTINGS = {
         "strict_validation": False,
         # path/to/mappings/dir - where mapping files will be expected
         "mappings_dir": "mappings",
+        # db alias to use for the SearchDocumentManagerMixin method
+        "in_search_queryset_db_alias": "foo",
     },
 }
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -241,29 +241,33 @@ class SearchDocumentManagerMixinTests:
         with pytest.raises(NotImplementedError):
             obj.get_search_queryset()
 
-    @mock.patch.object(ExampleModelManager, "get_search_queryset")
+    @mock.patch.object(ExampleModelManager, "get_search_queryset", autospec=True)
     def test_in_search_queryset(self, mock_qs):
         """Test the in_search_queryset method."""
         obj = ExampleModel(id=1, simple_field_1=1, simple_field_2="foo")
         ExampleModel.objects.in_search_queryset(obj.get_search_document_id())
-        mock_qs.assert_called_once_with(index="_all")
+        mock_qs.assert_called_once_with(ExampleModel.objects, index="_all")
         mock_qs.return_value.filter.assert_called_once_with(
             pk=obj.get_search_document_id()
         )
-        mock_qs.return_value.filter.return_value.exists.assert_called_once_with()
+        mock_qs.return_value.filter.return_value.using.assert_called_once_with("direct")
+        mock_qs.return_value.filter.return_value.using.return_value.exists.assert_called_once_with()
 
-    @mock.patch.object(ExampleModelManager, "get_search_queryset")
+    @mock.patch.object(ExampleModelManager, "get_search_queryset", autospec=True)
     def test_in_search_queryset_with_a_model_using_custom_primary_key(self, mock_qs):
         """Test the in_search_queryset method."""
         obj = ExampleModelWithCustomPrimaryKey(simple_field_1=1)
         ExampleModelWithCustomPrimaryKey.objects.in_search_queryset(
             obj.get_search_document_id()
         )
-        mock_qs.assert_called_once_with(index="_all")
+        mock_qs.assert_called_once_with(
+            ExampleModelWithCustomPrimaryKey.objects, index="_all"
+        )
         mock_qs.return_value.filter.assert_called_once_with(pk="1")
-        mock_qs.return_value.filter.return_value.exists.assert_called_once_with()
+        mock_qs.return_value.filter.return_value.using.assert_called_once_with("direct")
+        mock_qs.return_value.filter.return_value.using.return_value.exists.assert_called_once_with()
 
-    @mock.patch("django.db.models.query.QuerySet")
+    @mock.patch("django.db.models.query.QuerySet", autospec=True)
     def test_from_search_query(self, mock_qs):
         """Test the from_search_query method."""
         self.maxDiff = None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -250,7 +250,7 @@ class SearchDocumentManagerMixinTests:
         mock_qs.return_value.filter.assert_called_once_with(
             pk=obj.get_search_document_id()
         )
-        mock_qs.return_value.filter.return_value.using.assert_called_once_with("direct")
+        mock_qs.return_value.filter.return_value.using.assert_called_once_with("foo")
         mock_qs.return_value.filter.return_value.using.return_value.exists.assert_called_once_with()
 
     @mock.patch.object(ExampleModelManager, "get_search_queryset", autospec=True)
@@ -264,7 +264,7 @@ class SearchDocumentManagerMixinTests:
             ExampleModelWithCustomPrimaryKey.objects, index="_all"
         )
         mock_qs.return_value.filter.assert_called_once_with(pk="1")
-        mock_qs.return_value.filter.return_value.using.assert_called_once_with("direct")
+        mock_qs.return_value.filter.return_value.using.assert_called_once_with("foo")
         mock_qs.return_value.filter.return_value.using.return_value.exists.assert_called_once_with()
 
     @mock.patch("django.db.models.query.QuerySet", autospec=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
 isolated_build = True
 envlist = fmt, lint, mypy,
-    py{3.8,3.9}-django{32,40,41}
-    py{3.10,3.11}-django{32,40,41,main}
+    py38-django{32,40,41}
+    py39-django{32,40,41}
+    py310-django{32,40,41,42,main}
+    py311-django{41,42,main}
 
 [testenv]
 deps =
@@ -12,6 +14,7 @@ deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
Long story, but it turns out that if you use multiple database connections in your app you can end up in a situation where the `in_search_queryset` method cannot see a new object because it's running on a different connection from the one on which the object was created. Canonical example of this is when the `get_search_queryset` method is using an iterator and running on a connection that supports server-side cursors whilst the default connection is using connection pooling.

Edge case.