### PR TITLE
Add Django 6.x support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
             - name: Check out the repository
               uses: actions/checkout@v4
 
-            - name: Set up Python 3.11
+            - name: Set up Python 3.12
               uses: actions/setup-python@v1
               with:
-                  python-version: "3.11"
+                  python-version: "3.12"
 
             - name: Install and run tox
               run: |
@@ -37,13 +37,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python: ["3.10", "3.11", "3.12"]
-                django: ["42", "50", "52", "main"]
-                exclude:
-                    - django: "main"
-                      python: "3.10"
-                    - django: "main"
-                      python: "3.11"
+                python: ["3.12", "3.13"]
+                django: ["52", "60", "main"]
 
         env:
             TOXENV: py${{ matrix.python }}-django${{ matrix.django }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**This project now requires Python 3.10+ and Django 4.2+ (including Django 5.2).\
+**This project now requires Python 3.12+ and Django 5.2-6.0.\
 For previous versions please refer to the relevant tag or branch.**
 
 # Elasticsearch for Django

--- a/elasticsearch_django/signals.py
+++ b/elasticsearch_django/signals.py
@@ -1,13 +1,10 @@
 import django.dispatch
 
 # signal fired just before calling model.index_search_document
-# providing_args=["instance", "index"]
 pre_index = django.dispatch.Signal()
 
 # signal fired just before calling model.update_search_document
-# providing_args=["instance", "index", "update_fields"]
 pre_update = django.dispatch.Signal()
 
 # signal fired just before calling model.delete_search_document
-# providing_args=["instance", "index"]
 pre_delete = django.dispatch.Signal()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "elasticsearch-django"
-version = "8.6.0"
+version = "8.7.0"
 description = "Elasticsearch Django app."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -10,23 +10,21 @@ homepage = "https://github.com/yunojuno/elasticsearch-django"
 repository = "https://github.com/yunojuno/elasticsearch-django"
 classifiers = [
     "Environment :: Web Environment",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
-django = ">=4.2,<5.3"
+python = "^3.12"
+django = ">=5.2,<7.0"
 elasticsearch = "^8.0"
 simplejson = "*"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "*"
 coverage = "*"
 mypy = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,16 @@
 [tox]
 isolated_build = True
 envlist = fmt, lint, mypy,
-    py310-django{42,50,52,main}
-    py311-django{42,50,52,main}
-    py312-django{42,50,52,main}
+    py312-django{52,60,main}
+    py313-django{52,60,main}
 
 [testenv]
 deps =
     pytest
     pytest-cov
     pytest-django
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)